### PR TITLE
Fix for styleName and custom

### DIFF
--- a/src/PhpWord/Writer/Word2007/Style/Table.php
+++ b/src/PhpWord/Writer/Word2007/Style/Table.php
@@ -66,7 +66,15 @@ class Table extends AbstractStyle
     {
         // w:tblPr
         $xmlWriter->startElement('w:tblPr');
-
+        
+        //Support table style name and custom styles at the same time
+        //set style name 1st (so word sets its style 1st then any custom styles)
+        if($style->getStyleName() != ''){
+            $xmlWriter->startElement('w:tblStyle');
+            $xmlWriter->writeAttribute('w:val', $style->getStyleName());
+            $xmlWriter->endElement();            
+        }
+        
         // Table alignment
         if ('' !== $style->getAlignment()) {
             $tableAlignment = new TableAlignment($style->getAlignment());


### PR DESCRIPTION
Allows user to set both styleName and table style. Currently only one or the other.
Ex:
$section->addTable(array(
      "styleName" => "TBL2",
      "layout" => Table::LAYOUT_FIXED,
      "width"  => 75 * 50,
        "unit"   => TblWidth::PERCENT
));

### Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

Fixes # (issue)

### Checklist:

- [ ] I have run `composer run-script check --timeout=0` and no errors were reported
- [ ] The new code is covered by unit tests (check build/coverage for coverage report)
- [ ] I have updated the documentation to describe the changes
